### PR TITLE
Docker staticfiles volume error

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,7 @@ CSRF_TRUSTED_ORIGINS=http://localhost:8000
 
 # Database URL for Django
 DATABASE_URL=postgres://horilla_user:horilla_pass@db:5432/horilla_db
+
+# Optional: override static/media roots (useful for Docker)
+STATIC_ROOT=/static
+MEDIA_ROOT=/media

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ COPY . .
 
 # Set permissions
 RUN mkdir -p staticfiles media \
-    && chown -R appuser:appuser /app
+    && mkdir -p /static /media \
+    && chown -R appuser:appuser /app /static /media
 
 # Copy entrypoint
 COPY docker/entrypoint.sh /entrypoint.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,14 +5,16 @@ services:
       - "8000:8000"
     volumes:
       - .:/app
-      - staticfiles:/app/staticfiles
-      - media:/app/media
+      - staticfiles:/static
+      - media:/media
     environment:
       - DEBUG=1
       - SECRET_KEY=dev-secret-key
       - ALLOWED_HOSTS=localhost,127.0.0.1,0.0.0.0
       - CSRF_TRUSTED_ORIGINS=http://localhost:8000
       - DATABASE_URL=postgres://horilla_user:horilla_pass@db:5432/horilla_db
+      - STATIC_ROOT=/static
+      - MEDIA_ROOT=/media
     depends_on:
       - db
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -18,9 +18,3 @@ python manage.py collectstatic --noinput
 
 echo "Starting server..."
 exec "$@"
-
-# Collect static files
-python manage.py collectstatic --noinput
-
-echo "Starting server..."
-exec "$@"

--- a/horilla/settings/base.py
+++ b/horilla/settings/base.py
@@ -360,13 +360,13 @@ CELERY_TIMEZONE = "UTC"
 
 
 STATIC_URL = "/static/"
-STATIC_ROOT = BASE_DIR / "staticfiles"
+STATIC_ROOT = Path(env("STATIC_ROOT", default=str(BASE_DIR / "staticfiles")))
 STATICFILES_DIRS = [BASE_DIR / "static"]
 STATICFILES_STORAGE = "whitenoise.storage.CompressedStaticFilesStorage"
 
 
 MEDIA_URL = "/media/"
-MEDIA_ROOT = BASE_DIR / "media"
+MEDIA_ROOT = Path(env("MEDIA_ROOT", default=str(BASE_DIR / "media")))
 
 TIME_ZONE = "UTC"
 


### PR DESCRIPTION
Move static and media volumes to top-level paths (`/static`, `/media`) to resolve `permission denied` errors during Docker container startup.

The previous setup attempted to mount named volumes (`staticfiles`, `media`) inside a bind-mounted application directory (`/app`). This configuration can lead to `permission denied` errors on some Docker environments (e.g., Docker Desktop) when Docker tries to create the nested mount points. By mounting these volumes at the root level, we bypass this known Docker limitation.

---
<a href="https://cursor.com/background-agent?bcId=bc-4871e533-8f4e-4442-b0c9-4a8792d783ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4871e533-8f4e-4442-b0c9-4a8792d783ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

