### PR TITLE
Horilla CRM db password environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,7 @@ CSRF_TRUSTED_ORIGINS=http://localhost:8000
 
 # Database URL for Django
 DATABASE_URL=postgres://horilla_user:horilla_pass@db:5432/horilla_db
+
+# Initial database load password (optional)
+# If unset, a secure password is auto-generated and stored in .init_password
+DB_INIT_PASSWORD=change-me

--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ make clean    # Clean up
 - **Nginx**: Reverse proxy for production (port 80)
 
 ### Environment Variables
+Set `DB_INIT_PASSWORD` in your `.env` to control the database initialization
+password used by the data loader. If omitted, a secure password is generated
+and stored in `.init_password` inside the container.
 ```bash
 # PostgreSQL Database
 POSTGRES_DB=horilla_db
@@ -162,6 +165,11 @@ CSRF_TRUSTED_ORIGINS=http://localhost:8000
 
 # Database URL
 DATABASE_URL=postgres://horilla_user:horilla_pass@db:5432/horilla_db
+
+# Database initialization (optional)
+# Used for the initial data load password. If omitted, a secure
+# password is generated and stored in .init_password in the container.
+DB_INIT_PASSWORD=change-me
 ```
 
 ## 🏗️ Architecture


### PR DESCRIPTION
Document `DB_INIT_PASSWORD` and add it to `.env.example` to allow users to configure the database initialization password via environment variables.

---
<a href="https://cursor.com/background-agent?bcId=bc-fa808c18-1b10-4b1d-a0d8-27d31cadba04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fa808c18-1b10-4b1d-a0d8-27d31cadba04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

